### PR TITLE
Make <li>s in install section's fonts match

### DIFF
--- a/docs/install.css
+++ b/docs/install.css
@@ -13,6 +13,10 @@ h2 {
   color: black
 }
 
+.install li {
+  font-family: Helvetica, sans-serif;
+}
+
 pre {
   padding: 16px;
   background-color: #f6f8fa;


### PR DESCRIPTION
The list of features in the install section in the documentation had no styling applied, and still used the browser-default serif font. This didn't match the rest of the site. Now they use Helvetica, with the browser's sans-serif font as a backup - same as the `<p>` elements.