### PR TITLE
Support browserify

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -25,6 +25,10 @@ render(
 , document.getElementById('container'))
 ```
 
+### Browserify
+
+[`browserify`](https://npmjs.com/packages/browserify) is supported, but you have to install [`browserify-css@^0.12.0`](https://npmjs.com/packages/browserify-css) manually.
+
 ## Features
 
 * No dependencies, just React.

--- a/package.json
+++ b/package.json
@@ -30,5 +30,13 @@
     "jsx-loader": "0.13.2",
     "style-loader": "0.13.1",
     "webpack": "2.2.1"
+  },
+  "peerDependencies": {
+    "browserify-css": "^0.12.0"
+  },
+  "browserify": {
+    "transform": [
+      "browserify-css"
+    ]
   }
 }


### PR DESCRIPTION
Right now, this package cannot be used with `browserify`. Putting `browserify-css` into `peerDependencies` is suboptimal, because `npm` will emit warnings, but there is no `optionalPeerDependencies` field in `package.json`. see npm/npm#3066