### PR TITLE
Update to prop-types v15.5.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "author": "zamarrowski",
   "license": "ISC",
   "dependencies": {
-    "prop-types": "15.5.6",
+    "prop-types": "15.5.10",
     "react": "15.4.2",
     "react-dom": "15.4.2"
   },


### PR DESCRIPTION
React prop-types v15.5.6 has multiple issues (especially in production minified builds) and was recently depreciated with a suggestion to upgrade to v15.5.7 or higher. v15.5.10 is the most recent release, does not introduce any breaking changes, and seems to work perfectly fine with this package. By doing this we can get rid of a scary depreciation message whenever this package is installed :)