### PR TITLE
Allow for versions of React > 15.4

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -28,8 +28,7 @@
   },
   "dependencies": {
     "material-ui": "0.17.0",
-    "react": "15.4.2",
-    "react-dom": "15.4.2",
+    "react": ">= 15.4",
     "react-ionicons": "latest",
     "react-tap-event-plugin": "2.0.1"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-ionicons",
-  "version": "2.1.6",
+  "version": "2.2.0",
   "description": "A React SVG ionicon component",
   "main": "lib/index.js",
   "author": "zamarrowski",

--- a/package.json
+++ b/package.json
@@ -6,10 +6,9 @@
   "author": "zamarrowski",
   "license": "ISC",
   "dependencies": {
-    "prop-types": "15.5.10",
-    "react": "15.4.2",
-    "react-dom": "15.4.2",
-    "styled-components": "2.2.3"
+    "prop-types": ">= 15.5",
+    "react": ">= 15.4",
+    "styled-components": ">= 2.2"
   },
   "scripts": {
     "prepublish": "babel ./src --out-dir ./lib --source-maps --presets es2015,react,stage-2 --plugins babel-plugin-add-module-exports",


### PR DESCRIPTION
Removed `react-dom` as a dependency as well. Cheers!